### PR TITLE
Fix gemv_fast model loading

### DIFF
--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -52,7 +52,6 @@ class AWQConfig(QuantizationConfig):
                 f"AWQ, but got {self.weight_bits} bits.")
         self.pack_factor_int32 = 32 // self.weight_bits
         self.pack_factor_int16 = 16 // self.weight_bits
-        
         self.interleave = 4
 
     def __repr__(self) -> str:
@@ -146,7 +145,6 @@ class AWQLinearMethod(LinearMethodBase):
                 qzeros, {
                     "input_dim": 0,
                     "output_dim": 1,
-                    "packed_dim": 0,
                 })
             scales = Parameter(
                 torch.empty(
@@ -160,7 +158,6 @@ class AWQLinearMethod(LinearMethodBase):
                 scales, {
                     "input_dim": 0,
                     "output_dim": 1,
-                    "packed_dim": 0,
                 })
         else:
             qweight = Parameter(

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -39,10 +39,12 @@ class AWQConfig(QuantizationConfig):
         weight_bits: int,
         group_size: int,
         zero_point: bool,
+        version: str
     ) -> None:
         self.weight_bits = weight_bits
         self.group_size = group_size
         self.zero_point = zero_point
+        self.version = version
 
         if self.weight_bits != 4:
             raise ValueError(
@@ -50,6 +52,7 @@ class AWQConfig(QuantizationConfig):
                 f"AWQ, but got {self.weight_bits} bits.")
         self.pack_factor_int32 = 32 // self.weight_bits
         self.pack_factor_int16 = 16 // self.weight_bits
+        
         self.interleave = 4
 
     def __repr__(self) -> str:
@@ -79,7 +82,8 @@ class AWQConfig(QuantizationConfig):
         weight_bits = cls.get_from_keys(config, ["w_bit", "bits"])
         group_size = cls.get_from_keys(config, ["q_group_size", "group_size"])
         zero_point = cls.get_from_keys(config, ["zero_point"])
-        return cls(weight_bits, group_size, zero_point)
+        version = cls.get_from_keys(config, ["version"])
+        return cls(weight_bits, group_size, zero_point, version)
 
     def get_linear_method(self) -> "AWQLinearMethod":
         return AWQLinearMethod(self)
@@ -113,7 +117,7 @@ class AWQLinearMethod(LinearMethodBase):
                 "weight shape. This can be caused by too large "
                 "tensor parallel size.")
 
-        if self.quant_config:
+        if self.quant_config.version == "gemv_fast":
             qweight = Parameter(
                 torch.empty(
                     output_size_per_partition // self.quant_config.interleave,
@@ -128,7 +132,7 @@ class AWQLinearMethod(LinearMethodBase):
                     "output_dim": 0,
                     "packed_dim": 1,
                     "pack_factor": self.quant_config.pack_factor_int16,
-                    "interleave": self.quant_config.interleave,
+                    "awq_interleave": self.quant_config.interleave,
                 })
             qzeros = Parameter(
                 torch.empty(
@@ -143,7 +147,6 @@ class AWQLinearMethod(LinearMethodBase):
                     "input_dim": 0,
                     "output_dim": 1,
                     "packed_dim": 0,
-                    "pack_factor": self.quant_config.pack_factor_int32,
                 })
             scales = Parameter(
                 torch.empty(
@@ -158,13 +161,12 @@ class AWQLinearMethod(LinearMethodBase):
                     "input_dim": 0,
                     "output_dim": 1,
                     "packed_dim": 0,
-                    "pack_factor": self.quant_config.pack_factor_int32,
                 })
         else:
             qweight = Parameter(
                 torch.empty(
                     input_size_per_partition,
-                    output_size_per_partition // self.quant_config.pack_factor,
+                    output_size_per_partition // self.quant_config.pack_factor_int32,
                     dtype=torch.int32,
                 ),
                 requires_grad=False,
@@ -174,12 +176,12 @@ class AWQLinearMethod(LinearMethodBase):
                     "input_dim": 0,
                     "output_dim": 1,
                     "packed_dim": 1,
-                    "pack_factor": self.quant_config.pack_factor,
+                    "pack_factor": self.quant_config.pack_factor_int32,
                 })
             qzeros = Parameter(
                 torch.empty(
                     input_size_per_partition // self.quant_config.group_size,
-                    output_size_per_partition // self.quant_config.pack_factor,
+                    output_size_per_partition // self.quant_config.pack_factor_int32,
                     dtype=torch.int32,
                 ),
                 requires_grad=False,
@@ -189,7 +191,7 @@ class AWQLinearMethod(LinearMethodBase):
                     "input_dim": 0,
                     "output_dim": 1,
                     "packed_dim": 1,
-                    "pack_factor": self.quant_config.pack_factor,
+                    "pack_factor": self.quant_config.pack_factor_int32,
                 })
             scales = Parameter(
                 torch.empty(
@@ -216,19 +218,30 @@ class AWQLinearMethod(LinearMethodBase):
         qweight = weights["qweight"]
         scales = weights["scales"]
         qzeros = weights["qzeros"]
-        pack_factor = self.quant_config.pack_factor_int32
-        out_shape = (x.shape[:-1] + (qweight.shape[-1] * pack_factor, ))
         reshaped_x = x.reshape(-1, x.shape[-1])
-
-        # num_tokens >= threshold
-        FP16_MATMUL_HEURISTIC_CONDITION = x.shape[:-1].numel() >= 256
-
-        if FP16_MATMUL_HEURISTIC_CONDITION:
-            out = ops.awq_dequantize(qweight, scales, qzeros, 0, 0, 0)
-            out = torch.matmul(reshaped_x, out)
+        if self.quant_config.version == "gemv_fast":
+            out_shape = (x.shape[:-1] + (qweight.shape[0] * self.quant_config.interleave, ))
+            GEMM_HEURISTIC_CONDITION = x.shape[:-1].numel() >= 8
+            if not GEMM_HEURISTIC_CONDITION:
+                out = ops.awq_gemv_fast(
+                    reshaped_x, qweight, scales, qzeros, reshaped_x.shape[0],
+                    out_shape[-1], reshaped_x.shape[1], self.quant_config.group_size
+                )
+            else:
+                out = ops.awq_gemm_fast(reshaped_x, qweight, scales, qzeros)
         else:
-            out = ops.awq_gemm(reshaped_x, qweight, scales, qzeros,
-                               pack_factor)
+            pack_factor = self.quant_config.pack_factor_int32
+            out_shape = (x.shape[:-1] + (qweight.shape[-1] * pack_factor, ))
+
+            # num_tokens >= threshold
+            FP16_MATMUL_HEURISTIC_CONDITION = x.shape[:-1].numel() >= 256
+
+            if FP16_MATMUL_HEURISTIC_CONDITION:
+                out = ops.awq_dequantize(qweight, scales, qzeros, 0, 0, 0)
+                out = torch.matmul(reshaped_x, out)
+            else:
+                out = ops.awq_gemm(reshaped_x, qweight, scales, qzeros,
+                                   pack_factor)
         if bias is not None:
             out = out + bias
         return out.reshape(out_shape)


### PR DESCRIPTION
GEMV fast shares many similarities with marlin both in algorithm and packing. Additional measures are required for managing the tiling/interleaving process in order to properly load the weights.  Currently I following the practice in Marlin.  It may worth some refactoring in the future, for example, separate the `pack_factor` into `output_pack_factor` and `input_pack_factor`.

The code works for llama now, however more shape checks are needed especially because of the `calculate_zeros_width` padding.
